### PR TITLE
Allow configuring the value for open/closed pin state

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Software Installation:
     - **name**: The name for the garage door as it will appear on the controller app.
     - **relay_pin**: The GPIO pin connecting the RPi to the relay for that door.
     - **state_pin**: The GPIO pin conneting to the contact switch.
+    - **state_pin_closed_value**: The GPIO pin value (0 or 1) that indicates the door is closed. Defaults to 0.
     - **approx_time_to_close**: How long the garage door typically takes to close.
     - **approx_time_to_open**: How long the garage door typically takes to open.
 

--- a/config.json
+++ b/config.json
@@ -41,6 +41,7 @@
 			"name" : "Sarah",
 			"relay_pin" : 23,
 			"state_pin" : 17,
+			"state_pin_closed_value" : 0,
 			"approx_time_to_close" : 10,
 			"approx_time_to_open" : 13,
 			"openhab_name" : "g_door_left"
@@ -50,6 +51,7 @@
 			"name" : "Lior",
 			"relay_pin" : 24,
 			"state_pin" : 27,
+			"state_pin_closed_value" : 0,
 			"approx_time_to_close" : 10,
 			"approx_time_to_open" : 13,
 			"openhab_name" : "g_door_right"

--- a/controller.py
+++ b/controller.py
@@ -36,6 +36,7 @@ class Door(object):
         self.name = config['name']
         self.relay_pin = config['relay_pin']
         self.state_pin = config['state_pin']
+        self.state_pin_closed_value = config.get('state_pin_closed_value', 0)
         self.time_to_close = config.get('time_to_close', 10)
         self.time_to_open = config.get('time_to_open', 10)
         self.openhab_name = config.get('openhab_name')
@@ -45,7 +46,7 @@ class Door(object):
         gpio.output(self.relay_pin, True)
         
     def get_state(self):
-        if gpio.input(self.state_pin) == 0:
+        if gpio.input(self.state_pin) == self.state_pin_closed_value:
             return 'closed'
         elif self.last_action == 'open':
             if time.time() - self.last_action_time >= self.time_to_open:


### PR DESCRIPTION
I've setup my reed switches so that when the door is open, the reed switches line up. For my particular reed switches, this means when the door is closed, the state of the GPIO pin is 1 which is a little different from the original implementation so I added the ability to configure the state value in the config.json.
