### PR TITLE
Serve Over HTTPS With SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,22 @@ Software Installation:
     `svn co https://github.com/andrewshilliday/garage-door-controller/trunk ~pi/garage-door-controller`
     
     That's it; you don't need to build anything.
-
-5.  **Edit `config.json`**
+    
+5.  **Create SSL Certificates** (if desired).
+    
+    If you plan on using SSL by setting the **use_https** option to *true* in the `config.json` file, you will need to complete this step or provide your own private keys and certificate for secure communication.
+    
+    In order for secure communication to be allowed, the controller application needs SSL certificates.  To quickly generate SSL certificates, do the following:
+    
+    `mkdir -p /home/pi/garage-door-controller-cert`
+    
+    `openssl req -new -x509 -days 3650 -nodes -out /home/pi/garage-door-controller-cert/localhost.crt -newkey rsa:4096 -sha256 -keyout /home/pi/garage-door-controller-cert/localhost.key -subj "/CN=localhost"`
+    
+    `chmod 700 /home/pi/garage-door-controller-cert`
+    
+    `chmod 600 /home/pi/garage-door-controller-cert/*`
+    
+6.  **Edit `config.json`**
     
     You'll need one configuration entry for each garage door.  The settings are fairly obvious, but are defined as follows:
     - **name**: The name for the garage door as it will appear on the controller app.
@@ -100,16 +114,17 @@ Software Installation:
     The **approx_time_to_XXX** options are not particularly crucial.  They tell the program when to shift from the opening or closing state to the "open" or "closed" state.  You don't need to be out there with a stopwatch and you wont break anything if they are off.  In the worst case, you may end up with a slightly odd behavior when closing the garage door whereby it goes from "closing" to "open" (briefly) and then to "closed" when the sensor detects that the door is actually closed.
 
         
-6.  **Set to launch at startup**
+7.  **Set to launch at startup**
 
     Simply add the following line to your /etc/rc.local file, just above the call to `exit 0`:
     
     `(cd ~pi/garage-door-controller; python controller.py)&`
     
-7. **Using the Controller Web Service**
-The garage door controller application runs directly from the Raspberry Pi as a web service running on port 8080.  It can be used by directing a web browser (on a PC or mobile device) to http://[hostname-or-ip-address]:8080/.  If you want to connect to the raspberry pi from outside your home network, you will need to establish port forwarding in your cable modem.  
-<br>
-When the app is open in your web browser, it should display one entry for each garage door configured in your `config.json` file, along with the current status and timestamp from the time the status was last changed.  Click on any entry to open or close the door (each click will behave as if you pressed the garage button once).
+8. **Using the Controller Web Service**
+
+    The garage door controller application runs directly from the Raspberry Pi as a web service running on port **8081**, or port **8444** when HTTPS is enabled.  It can be used by directing a web browser (on a PC or mobile device) to **http://[hostname-or-ip-address]:8081/**, or **https://[hostname-or-ip-address]:8444/** when HTTPS is enabled.  If you want to connect to the raspberry pi from outside your home network, you will need to establish port forwarding in your cable modem.  
+    
+    When the app is open in your web browser, it should display one entry for each garage door configured in your `config.json` file, along with the current status and timestamp from the time the status was last changed.  Click on any entry to open or close the door (each click will behave as if you pressed the garage button once).
 
 TODO:
 ----------  
@@ -117,7 +132,6 @@ This section contains the features I would like to add to the application, but d
 
 * *Security*: Impose a configurable password on the web service.  Would need to discuss the best strategy (i.e., should we require the pw every time, or can the session persist on any given device which has authenticated).
 * *New Feature*: Add a "close all" button to the bottom of the page to close all doors that have a state other than "closed" or "closing"
-* *Configuration*: Make the port number a configuration option
 * *Occupancy sensors*: Add proximity sensors to check if car port is in use
 * *IFTTT Integration*: make a smooth secure way to call the door and get information online
 

--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {  
     "config":{  
+        "use_https":false,
         "use_auth":true,
         "use_alerts":true,
         "use_openhab":false
@@ -30,8 +31,11 @@
     },
     "site":{  
         "port":8081,
+        "port_secure":8444,
         "username":"user",
-        "password":"12345"
+        "password":"12345",
+        "ssl_key":"/home/pi/garage-door-controller-cert/localhost.key",
+        "ssl_cert":"/home/pi/garage-door-controller-cert/localhost.crt"
     },
     "doors":{  
         "left":{  


### PR DESCRIPTION
I have been using this software for a number of years but with customization's for my own setup and have decided to contribute some back. This pull request will add the ability for the garage controller software to serve the web application with SSL for secure communication using HTTPS.

To maintain simplicity, this provides the option to switch HTTPS on. It does not handle communication on both HTTP and HTTPS ports at the same time. The end user must choose HTTP or HTTPS.